### PR TITLE
Fix TodoModal interface after merge

### DIFF
--- a/src/components/TodoModal.tsx
+++ b/src/components/TodoModal.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Dialog } from 'radix-ui';
 import type { TodoStatus } from '../types/Todo';
+
+interface TodoModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onSave: (data: {
     title: string;
     detail: string;


### PR DESCRIPTION
## Summary
- restore lost `TodoModalProps` interface after merge conflict

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f14ab6cac832aa0dd861721d98561