### PR TITLE
Use Radix icons for editing and modal controls

### DIFF
--- a/src/components/TodoModal.tsx
+++ b/src/components/TodoModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Cross2Icon } from '@radix-ui/react-icons';
 import { Dialog } from 'radix-ui';
 import type { TodoStatus } from '../types/Todo';
 
@@ -80,9 +81,10 @@ const TodoModal = ({ open, onOpenChange, onSave, initialTodo }: TodoModalProps) 
           <div className="flex justify-end gap-2">
             <button
               onClick={() => onOpenChange(false)}
-              className="rounded bg-gray-200 px-3 py-1 hover:bg-gray-300"
+              className="rounded bg-gray-200 p-2 hover:bg-gray-300"
+              aria-label="cancel"
             >
-              취소
+              <Cross2Icon />
             </button>
             <button
               onClick={handleSave}

--- a/src/pages/todo/Todos.tsx
+++ b/src/pages/todo/Todos.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Pencil1Icon, PlusIcon } from '@radix-ui/react-icons';
 import TodoModal from '../../components/TodoModal';
 
 import type { Todo, TodoStatus } from '../../types/Todo';
@@ -43,8 +44,12 @@ const Todos = () => {
     <div className="mx-auto max-w-md p-4">
       <div className="mb-4 flex items-center justify-between">
         <h1 className="text-2xl font-bold">Todo List</h1>
-        <button onClick={handleAddClick} className="rounded bg-blue-500 px-3 py-1 text-white hover:bg-blue-600">
-          +
+        <button
+          onClick={handleAddClick}
+          className="rounded bg-blue-500 p-2 text-white hover:bg-blue-600"
+          aria-label="add todo"
+        >
+          <PlusIcon />
         </button>
       </div>
       <ul className="space-y-2">
@@ -60,8 +65,12 @@ const Todos = () => {
               <span>Created: {todo.createdAt}</span>
             </div>
             <div className="mt-1 flex justify-end gap-2">
-              <button onClick={() => handleEdit(todo)} className="rounded bg-green-500 px-2 py-1 text-white hover:bg-green-600">
-                수정
+              <button
+                onClick={() => handleEdit(todo)}
+                className="rounded bg-green-500 p-2 text-white hover:bg-green-600"
+                aria-label="edit todo"
+              >
+                <Pencil1Icon />
               </button>
               <button onClick={() => handleDelete(todo.id)} className="rounded bg-red-500 px-2 py-1 text-white hover:bg-red-600">
                 삭제


### PR DESCRIPTION
## Summary
- switch add and edit buttons to Radix icons
- switch cancel button in TodoModal to a Radix icon

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687f1771ff00832aaea28985f087cd55