### PR TITLE
Add checklist feature to todo modal

### DIFF
--- a/src/components/TodoModal.tsx
+++ b/src/components/TodoModal.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
-import { Cross2Icon } from '@radix-ui/react-icons';
-import { Dialog } from 'radix-ui';
-import type { TodoStatus } from '../types/Todo';
+import { useEffect, useState } from "react";
+import { Cross2Icon } from "@radix-ui/react-icons";
+import { Dialog } from "radix-ui";
+import type { ChecklistItem, TodoStatus } from "../types/Todo";
 
 interface TodoModalProps {
   open: boolean;
@@ -11,31 +11,52 @@ interface TodoModalProps {
     detail: string;
     dueDate: string;
     status: TodoStatus;
+    checklist: ChecklistItem[];
   }) => void;
   initialTodo?: {
     title?: string;
     detail?: string;
     dueDate?: string;
     status?: TodoStatus;
+    checklist?: ChecklistItem[];
   };
 }
 
-const TodoModal = ({ open, onOpenChange, onSave, initialTodo }: TodoModalProps) => {
-  const [title, setTitle] = useState(initialTodo?.title ?? '');
-  const [detail, setDetail] = useState(initialTodo?.detail ?? '');
-  const [dueDate, setDueDate] = useState(initialTodo?.dueDate ?? '');
-  const [status, setStatus] = useState<TodoStatus>(initialTodo?.status ?? 'TODO');
+const TodoModal = ({
+  open,
+  onOpenChange,
+  onSave,
+  initialTodo,
+}: TodoModalProps) => {
+  const [title, setTitle] = useState(initialTodo?.title ?? "");
+  const [detail, setDetail] = useState(initialTodo?.detail ?? "");
+  const [dueDate, setDueDate] = useState(initialTodo?.dueDate ?? "");
+  const [status, setStatus] = useState<TodoStatus>(
+    initialTodo?.status ?? "TODO",
+  );
+  const [checklist, setChecklist] = useState<ChecklistItem[]>(
+    initialTodo?.checklist ?? [],
+  );
+  const [editingId, setEditingId] = useState<number | null>(null);
 
   useEffect(() => {
-    setTitle(initialTodo?.title ?? '');
-    setDetail(initialTodo?.detail ?? '');
-    setDueDate(initialTodo?.dueDate ?? '');
-    setStatus(initialTodo?.status ?? 'TODO');
+    setTitle(initialTodo?.title ?? "");
+    setDetail(initialTodo?.detail ?? "");
+    setDueDate(initialTodo?.dueDate ?? "");
+    setStatus(initialTodo?.status ?? "TODO");
+    setChecklist(initialTodo?.checklist ?? []);
+    setEditingId(null);
   }, [initialTodo]);
 
   const handleSave = () => {
     if (title.trim()) {
-      onSave({ title: title.trim(), detail: detail.trim(), dueDate, status });
+      onSave({
+        title: title.trim(),
+        detail: detail.trim(),
+        dueDate,
+        status,
+        checklist,
+      });
     }
   };
 
@@ -48,7 +69,7 @@ const TodoModal = ({ open, onOpenChange, onSave, initialTodo }: TodoModalProps) 
           <div className="mb-2">
             <input
               value={title}
-              onChange={e => setTitle(e.target.value)}
+              onChange={(e) => setTitle(e.target.value)}
               className="w-full rounded border p-2"
               placeholder="Title"
             />
@@ -56,21 +77,83 @@ const TodoModal = ({ open, onOpenChange, onSave, initialTodo }: TodoModalProps) 
           <div className="mb-2">
             <textarea
               value={detail}
-              onChange={e => setDetail(e.target.value)}
+              onChange={(e) => setDetail(e.target.value)}
               className="w-full rounded border p-2"
               placeholder="Detail"
             />
+          </div>
+          <div className="mb-2 space-y-1">
+            {checklist.map((item) => {
+              return (
+                <div key={item.id} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={item.done}
+                    onChange={(e) =>
+                      setChecklist((prev) =>
+                        prev.map((ci) =>
+                          ci.id === item.id
+                            ? { ...ci, done: e.target.checked }
+                            : ci,
+                        ),
+                      )
+                    }
+                  />
+                  {editingId === item.id ? (
+                    <input
+                      autoFocus
+                      value={item.text}
+                      onChange={(e) =>
+                        setChecklist((prev) =>
+                          prev.map((ci) =>
+                            ci.id === item.id
+                              ? { ...ci, text: e.target.value }
+                              : ci,
+                          ),
+                        )
+                      }
+                      onBlur={() => setEditingId(null)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          setEditingId(null);
+                        }
+                      }}
+                      className="flex-1 rounded border p-1"
+                    />
+                  ) : (
+                    <span
+                      onDoubleClick={() => setEditingId(item.id)}
+                      className={`flex-1 ${item.done ? "line-through text-gray-500" : ""}`}
+                    >
+                      {item.text || "새 항목"}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+            <button
+              type="button"
+              onClick={() =>
+                setChecklist((prev) => [
+                  ...prev,
+                  { id: Date.now(), text: "", done: false },
+                ])
+              }
+              className="rounded bg-gray-200 px-2 py-1 text-sm hover:bg-gray-300"
+            >
+              +
+            </button>
           </div>
           <div className="mb-2 flex gap-2">
             <input
               type="date"
               value={dueDate}
-              onChange={e => setDueDate(e.target.value)}
+              onChange={(e) => setDueDate(e.target.value)}
               className="flex-1 rounded border p-2"
             />
             <select
               value={status}
-              onChange={e => setStatus(e.target.value as TodoStatus)}
+              onChange={(e) => setStatus(e.target.value as TodoStatus)}
               className="flex-1 rounded border p-2"
             >
               <option value="TODO">TODO</option>

--- a/src/pages/todo/Todos.tsx
+++ b/src/pages/todo/Todos.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
-import { Pencil1Icon, PlusIcon } from '@radix-ui/react-icons';
-import TodoModal from '../../components/TodoModal';
+import { useState } from "react";
+import { Pencil1Icon, PlusIcon } from "@radix-ui/react-icons";
+import TodoModal from "../../components/TodoModal";
 
-import type { Todo, TodoStatus } from '../../types/Todo';
+import type { Todo, TodoStatus, ChecklistItem } from "../../types/Todo";
 
 const Todos = () => {
   const [todos, setTodos] = useState<Todo[]>([]);
@@ -14,15 +14,21 @@ const Todos = () => {
     setOpen(true);
   };
 
-  const handleSave = (data: { title: string; detail: string; dueDate: string; status: TodoStatus }) => {
+  const handleSave = (data: {
+    title: string;
+    detail: string;
+    dueDate: string;
+    status: TodoStatus;
+    checklist: ChecklistItem[];
+  }) => {
     if (editing) {
-      setTodos(todos.map(t => (t.id === editing.id ? { ...t, ...data } : t)));
+      setTodos(todos.map((t) => (t.id === editing.id ? { ...t, ...data } : t)));
     } else {
       setTodos([
         ...todos,
         {
           id: Date.now(),
-          createdAt: new Date().toISOString().split('T')[0],
+          createdAt: new Date().toISOString().split("T")[0],
           ...data,
         },
       ]);
@@ -32,7 +38,7 @@ const Todos = () => {
   };
 
   const handleDelete = (id: number) => {
-    setTodos(todos.filter(t => t.id !== id));
+    setTodos(todos.filter((t) => t.id !== id));
   };
 
   const handleEdit = (todo: Todo) => {
@@ -53,7 +59,7 @@ const Todos = () => {
         </button>
       </div>
       <ul className="space-y-2">
-        {todos.map(todo => (
+        {todos.map((todo) => (
           <li key={todo.id} className="flex flex-col gap-1 rounded border p-2">
             <div className="flex justify-between">
               <span className="font-semibold">{todo.title}</span>
@@ -72,7 +78,10 @@ const Todos = () => {
               >
                 <Pencil1Icon />
               </button>
-              <button onClick={() => handleDelete(todo.id)} className="rounded bg-red-500 px-2 py-1 text-white hover:bg-red-600">
+              <button
+                onClick={() => handleDelete(todo.id)}
+                className="rounded bg-red-500 px-2 py-1 text-white hover:bg-red-600"
+              >
                 삭제
               </button>
             </div>
@@ -81,7 +90,7 @@ const Todos = () => {
       </ul>
       <TodoModal
         open={open}
-        onOpenChange={o => {
+        onOpenChange={(o) => {
           setOpen(o);
           if (!o) setEditing(null);
         }}

--- a/src/types/Todo.ts
+++ b/src/types/Todo.ts
@@ -1,4 +1,10 @@
-export type TodoStatus = 'TODO' | 'PROGRESS' | 'DONE';
+export type TodoStatus = "TODO" | "PROGRESS" | "DONE";
+
+export interface ChecklistItem {
+  id: number;
+  text: string;
+  done: boolean;
+}
 
 export interface Todo {
   id: number;
@@ -7,4 +13,5 @@ export interface Todo {
   dueDate: string;
   createdAt: string;
   status: TodoStatus;
+  checklist: ChecklistItem[];
 }


### PR DESCRIPTION
## Summary
- allow editing `Todo` checklist items
- add `ChecklistItem` type and new `checklist` field for `Todo`

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687f1aa0a798832a906280f4a918610c