### PR TITLE
Reset modal when opened

### DIFF
--- a/src/components/TodoModal.tsx
+++ b/src/components/TodoModal.tsx
@@ -40,13 +40,15 @@ const TodoModal = ({
   const [editingId, setEditingId] = useState<number | null>(null);
 
   useEffect(() => {
-    setTitle(initialTodo?.title ?? "");
-    setDetail(initialTodo?.detail ?? "");
-    setDueDate(initialTodo?.dueDate ?? "");
-    setStatus(initialTodo?.status ?? "TODO");
-    setChecklist(initialTodo?.checklist ?? []);
-    setEditingId(null);
-  }, [initialTodo]);
+    if (open) {
+      setTitle(initialTodo?.title ?? "");
+      setDetail(initialTodo?.detail ?? "");
+      setDueDate(initialTodo?.dueDate ?? "");
+      setStatus(initialTodo?.status ?? "TODO");
+      setChecklist(initialTodo?.checklist ?? []);
+      setEditingId(null);
+    }
+  }, [initialTodo, open]);
 
   const handleSave = () => {
     if (title.trim()) {


### PR DESCRIPTION
## Summary
- reset all todo modal fields when opening the modal

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687f2894e120832abcb2cfc544764cb9