### PR TITLE
Use Outlet for mobile layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,15 @@ import "./App.css";
 import { Route, Routes } from "react-router";
 import Todos from "./pages/todo/Todos";
 import Home from "./pages/home/Home";
+import MobileLayout from "./components/MobileLayout";
 
 function App() {
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/todos" element={<Todos />} />
+      <Route element={<MobileLayout />}>
+        <Route index element={<Home />} handle={{ title: 'Home' }} />
+        <Route path="todos" element={<Todos />} handle={{ title: 'Todo List' }} />
+      </Route>
     </Routes>
   );
 }

--- a/src/components/MobileLayout.tsx
+++ b/src/components/MobileLayout.tsx
@@ -1,17 +1,16 @@
-import type { ReactNode } from 'react';
-
-interface MobileLayoutProps {
-  title: string;
-  children: ReactNode;
-}
-
-const MobileLayout = ({ title, children }: MobileLayoutProps) => {
+import { Outlet, useMatches } from 'react-router';
+const MobileLayout = () => {
+  const matches = useMatches();
+  const lastMatch = matches[matches.length - 1] as { handle?: { title?: string } };
+  const title = lastMatch?.handle?.title ?? '';
   return (
     <div className="mx-auto flex h-screen max-w-[400px] flex-col overflow-hidden rounded-lg border shadow-lg">
       <header className="shrink-0 bg-blue-600 p-4 text-center text-lg font-semibold text-white">
         {title}
       </header>
-      <main className="flex-1 overflow-y-auto bg-white">{children}</main>
+      <main className="flex-1 overflow-y-auto bg-white">
+        <Outlet />
+      </main>
     </div>
   );
 };

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,19 +1,16 @@
 import { useNavigate } from 'react-router';
-import MobileLayout from '../../components/MobileLayout';
 
 const Home = () => {
   const navigate = useNavigate();
   return (
-    <MobileLayout title="Home">
-      <div className="flex h-full items-center justify-center p-4">
-        <button
-          onClick={() => navigate('/todos')}
-          className="rounded bg-blue-500 px-4 py-2 text-white"
-        >
-          Todo List
-        </button>
-      </div>
-    </MobileLayout>
+    <div className="flex h-full items-center justify-center p-4">
+      <button
+        onClick={() => navigate('/todos')}
+        className="rounded bg-blue-500 px-4 py-2 text-white"
+      >
+        Todo List
+      </button>
+    </div>
   );
 };
 

--- a/src/pages/todo/Todos.tsx
+++ b/src/pages/todo/Todos.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { Pencil1Icon, PlusIcon } from '@radix-ui/react-icons';
 import TodoModal from '../../components/TodoModal';
-import MobileLayout from '../../components/MobileLayout';
 
 import type { Todo, TodoStatus, ChecklistItem } from '../../types/Todo';
 
@@ -48,7 +47,7 @@ const Todos = () => {
   };
 
   return (
-    <MobileLayout title="Todo List">
+    <>
       <div className="mb-4 flex items-center justify-between">
         <h1 className="text-2xl font-bold">Todo List</h1>
         <button
@@ -98,7 +97,7 @@ const Todos = () => {
         onSave={handleSave}
         initialTodo={editing ?? undefined}
       />
-    </MobileLayout>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- centralize layout using React Router's `Outlet`
- update routes to use layout handles for page titles
- remove layout wrapping from individual pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688170e40834832a8ab702fe98897541