### PR TITLE
Fix mobile double-tap zoom in Todo modal

### DIFF
--- a/src/components/TodoModal.tsx
+++ b/src/components/TodoModal.tsx
@@ -127,8 +127,13 @@ const TodoModal = ({
                     />
                   ) : (
                     <span
-                      onDoubleClick={() => setEditingId(item.id)}
-                      className={`flex-1 ${item.done ? "line-through text-gray-500" : ""}`}
+                      onDoubleClick={(e) => {
+                        e.preventDefault();
+                        setEditingId(item.id);
+                      }}
+                      className={`flex-1 touch-manipulation ${
+                        item.done ? "line-through text-gray-500" : ""
+                      }`}
                     >
                       {item.text || "새 항목"}
                     </span>


### PR DESCRIPTION
## Summary
- prevent browser zoom on mobile double-tap when editing checklist items

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68817ec32ba8832a82994a361bfed286