### PR TITLE
Refine UI using shadcn theme

### DIFF
--- a/src/components/TodoModal.tsx
+++ b/src/components/TodoModal.tsx
@@ -1,7 +1,11 @@
-import { useEffect, useState } from "react";
-import { Cross2Icon } from "@radix-ui/react-icons";
-import { Dialog } from "radix-ui";
-import type { ChecklistItem, TodoStatus } from "../types/Todo";
+import { useEffect, useState } from 'react';
+import { Cross2Icon } from '@radix-ui/react-icons';
+import { Dialog } from 'radix-ui';
+import type { ChecklistItem, TodoStatus } from '../types/Todo';
+import { Input } from './ui/Input';
+import { Textarea } from './ui/Textarea';
+import { Select } from './ui/Select';
+import { Button } from './ui/Button';
 
 interface TodoModalProps {
   open: boolean;
@@ -65,24 +69,14 @@ const TodoModal = ({
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/40" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 w-96 -translate-x-1/2 -translate-y-1/2 rounded-md bg-background p-4 shadow">
+        <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 w-96 -translate-x-1/2 -translate-y-1/2 rounded-lg border bg-background p-4 shadow-2xl">
           <Dialog.Title className="mb-2 text-lg font-bold">Todo</Dialog.Title>
           <div className="mb-2">
-            <input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className="w-full rounded border p-2"
-              placeholder="Title"
-            />
+            <Input value={title} onChange={e => setTitle(e.target.value)} placeholder="Title" />
           </div>
           <div className="mb-2">
-            <textarea
-              value={detail}
-              onChange={(e) => setDetail(e.target.value)}
-              className="w-full rounded border p-2"
-              placeholder="Detail"
-            />
+            <Textarea value={detail} onChange={e => setDetail(e.target.value)} placeholder="Detail" />
           </div>
           <div className="mb-2 space-y-1">
             <div className="text-sm font-medium">
@@ -105,25 +99,23 @@ const TodoModal = ({
                     }
                   />
                   {editingId === item.id ? (
-                    <input
+                    <Input
                       autoFocus
                       value={item.text}
-                      onChange={(e) =>
-                        setChecklist((prev) =>
-                          prev.map((ci) =>
-                            ci.id === item.id
-                              ? { ...ci, text: e.target.value }
-                              : ci,
+                      onChange={e =>
+                        setChecklist(prev =>
+                          prev.map(ci =>
+                            ci.id === item.id ? { ...ci, text: e.target.value } : ci,
                           ),
                         )
                       }
                       onBlur={() => setEditingId(null)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
+                      onKeyDown={e => {
+                        if (e.key === 'Enter') {
                           setEditingId(null);
                         }
                       }}
-                      className="flex-1 rounded border p-1"
+                      className="flex-1 p-1"
                     />
                   ) : (
                     <span
@@ -151,52 +143,51 @@ const TodoModal = ({
                 </div>
               );
             })}
-            <button
+            <Button
               type="button"
+              variant="secondary"
               onClick={() =>
-                setChecklist((prev) =>
+                setChecklist(prev =>
                   prev.length < 10
-                    ? [...prev, { id: Date.now(), text: "", done: false }]
+                    ? [...prev, { id: Date.now(), text: '', done: false }]
                     : prev,
                 )
               }
               disabled={checklist.length >= 10}
-              className="rounded bg-secondary px-2 py-1 text-sm text-secondary-foreground hover:bg-secondary/80 disabled:opacity-50"
+              className="px-2 py-1 text-sm"
             >
               +
-            </button>
+            </Button>
           </div>
           <div className="mb-2 flex gap-2">
-            <input
+            <Input
               type="date"
               value={dueDate}
-              onChange={(e) => setDueDate(e.target.value)}
-              className="flex-1 rounded border p-2"
+              onChange={e => setDueDate(e.target.value)}
+              className="flex-1"
             />
-            <select
+            <Select
               value={status}
-              onChange={(e) => setStatus(e.target.value as TodoStatus)}
-              className="flex-1 rounded border p-2"
+              onChange={e => setStatus(e.target.value as TodoStatus)}
+              className="flex-1"
             >
               <option value="TODO">TODO</option>
               <option value="PROGRESS">PROGRESS</option>
               <option value="DONE">DONE</option>
-            </select>
+            </Select>
           </div>
           <div className="flex justify-end gap-2">
-            <button
+            <Button
+              variant="secondary"
               onClick={() => onOpenChange(false)}
-              className="rounded bg-secondary p-2 text-secondary-foreground hover:bg-secondary/80"
+              className="p-2"
               aria-label="cancel"
             >
               <Cross2Icon />
-            </button>
-            <button
-              onClick={handleSave}
-              className="rounded bg-primary px-3 py-1 text-primary-foreground hover:bg-primary/90"
-            >
+            </Button>
+            <Button onClick={handleSave} className="px-3 py-1">
               저장
-            </button>
+            </Button>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,18 @@
+import type { HTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: 'default' | 'secondary' | 'destructive' | 'outline';
+}
+
+const base = 'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors';
+const variants = {
+  default: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
+  secondary: 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+  destructive: 'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
+  outline: 'text-foreground',
+};
+
+export function Badge({ variant = 'default', className, ...props }: BadgeProps) {
+  return <span className={cn(base, variants[variant], className)} {...props} />;
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,18 @@
+import type { ButtonHTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'secondary' | 'destructive';
+}
+
+const base =
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+const variants = {
+  default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+  destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+};
+
+export function Button({ variant = 'default', className, ...props }: ButtonProps) {
+  return <button className={cn(base, variants[variant], className)} {...props} />;
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,16 @@
+import type { InputHTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {}
+
+export function Input({ className, ...props }: InputProps) {
+  return (
+    <input
+      className={cn(
+        'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,0 +1,16 @@
+import type { SelectHTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+
+export interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {}
+
+export function Select({ className, ...props }: SelectProps) {
+  return (
+    <select
+      className={cn(
+        'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/Textarea.tsx
+++ b/src/components/ui/Textarea.tsx
@@ -1,0 +1,16 @@
+import type { TextareaHTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export function Textarea({ className, ...props }: TextareaProps) {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,15 +1,11 @@
 import { useNavigate } from 'react-router';
+import { Button } from '../../components/ui/Button';
 
 const Home = () => {
   const navigate = useNavigate();
   return (
     <div className="flex h-full items-center justify-center p-4">
-      <button
-        onClick={() => navigate('/todos')}
-        className="rounded bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
-      >
-        Todo List
-      </button>
+      <Button onClick={() => navigate('/todos')}>Todo List</Button>
     </div>
   );
 };

--- a/src/pages/todo/Todos.tsx
+++ b/src/pages/todo/Todos.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Pencil1Icon, PlusIcon } from '@radix-ui/react-icons';
 import TodoModal from '../../components/TodoModal';
+import { Button } from '../../components/ui/Button';
+import { Badge } from '../../components/ui/Badge';
 
 import type { Todo, TodoStatus, ChecklistItem } from '../../types/Todo';
 
@@ -66,20 +68,18 @@ const Todos = () => {
     <>
       <div className="mb-4 flex items-center justify-between">
         <h1 className="text-2xl font-bold">Todo List</h1>
-        <button
-          onClick={handleAddClick}
-          className="rounded bg-primary p-2 text-primary-foreground hover:bg-primary/90"
-          aria-label="add todo"
-        >
+        <Button onClick={handleAddClick} className="p-2" aria-label="add todo">
           <PlusIcon />
-        </button>
+        </Button>
       </div>
       <ul className="space-y-2">
         {todos.map(todo => (
-          <li key={todo.id} className="flex flex-col gap-1 rounded border p-2">
+          <li key={todo.id} className="flex flex-col gap-1 rounded-lg border bg-card p-4 text-card-foreground">
             <div className="flex justify-between">
               <span className="font-semibold">{todo.title}</span>
-              <span className="text-sm text-muted-foreground">{todo.status}</span>
+              <Badge variant={todo.status === 'PROGRESS' ? 'default' : todo.status === 'DONE' ? 'outline' : 'secondary'}>
+                {todo.status}
+              </Badge>
             </div>
             <p className="text-sm text-muted-foreground">{todo.detail}</p>
             <div className="flex justify-between text-xs text-muted-foreground">
@@ -87,19 +87,12 @@ const Todos = () => {
               <span>Created: {todo.createdAt}</span>
             </div>
             <div className="mt-1 flex justify-end gap-2">
-              <button
-                onClick={() => handleEdit(todo)}
-                className="rounded bg-secondary p-2 text-secondary-foreground hover:bg-secondary/80"
-                aria-label="edit todo"
-              >
+              <Button variant="secondary" onClick={() => handleEdit(todo)} className="p-2" aria-label="edit todo">
                 <Pencil1Icon />
-              </button>
-              <button
-                onClick={() => handleDelete(todo.id)}
-                className="rounded bg-destructive px-2 py-1 text-destructive-foreground hover:bg-destructive/90"
-              >
+              </Button>
+              <Button variant="destructive" onClick={() => handleDelete(todo.id)} className="px-2 py-1">
                 삭제
-              </button>
+              </Button>
             </div>
           </li>
         ))}

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...inputs: Array<string | false | null | undefined>) {
+  return inputs.filter(Boolean).join(' ');
+}


### PR DESCRIPTION
## Summary
- add utility `cn`
- create basic `shadcn`-style UI components (Button, Input, Textarea, Select, Badge)
- refactor Home, Todos and TodoModal to use new components
- update modal styling for better default theme look

## Testing
- `pnpm run build`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68818939d744832a869c402831537655