### PR TITLE
Refactor Todos tests to use user-event

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@svgr/rollup": "^8.1.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8
@@ -2096,6 +2099,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -6512,6 +6521,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
 
   '@trysound/sax@0.2.0': {}
 

--- a/src/components/TodoModal.test.tsx
+++ b/src/components/TodoModal.test.tsx
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import TodoModal from "./TodoModal";
+
+const baseTodo = {
+  title: "Test Todo",
+  detail: "Test Detail",
+  dueDate: "2025-12-31",
+  status: "TODO" as const,
+  checklist: [{ id: 1, text: "Item 1", done: false }],
+};
 
 describe("TodoModal", () => {
   it("renders correctly when open", () => {
@@ -14,19 +23,7 @@ describe("TodoModal", () => {
         open={true}
         onOpenChange={onOpenChangeMock}
         onSave={onSaveMock}
-        initialTodo={{
-          title: "Test Todo",
-          detail: "Test Detail",
-          dueDate: "2025-12-31",
-          status: "TODO",
-          checklist: [
-            {
-              id: 1,
-              text: "Item 1",
-              done: false,
-            },
-          ],
-        }}
+        initialTodo={baseTodo}
       />
     );
 
@@ -48,19 +45,7 @@ describe("TodoModal", () => {
         open={true}
         onOpenChange={onOpenChangeMock}
         onSave={onSaveMock}
-        initialTodo={{
-          title: "Test Todo",
-          detail: "Test Detail",
-          dueDate: "2025-12-31",
-          status: "TODO",
-          checklist: [
-            {
-              id: 1,
-              text: "Item 1",
-              done: false,
-            },
-          ],
-        }}
+        initialTodo={baseTodo}
       />
     );
 
@@ -93,7 +78,7 @@ describe("TodoModal", () => {
     expect(screen.queryByTestId("todo-modal")).not.toBeInTheDocument();
   });
 
-  it("closes when the overlay is clicked", () => {
+  it("closes when the overlay is clicked", async () => {
     // given
     const onOpenChangeMock = vi.fn();
     const onSaveMock = vi.fn();
@@ -103,34 +88,22 @@ describe("TodoModal", () => {
         open={true}
         onOpenChange={onOpenChangeMock}
         onSave={onSaveMock}
-        initialTodo={{
-          title: "Test Todo",
-          detail: "",
-          dueDate: "",
-          status: "TODO",
-          checklist: [],
-        }}
+        initialTodo={{ ...baseTodo, detail: "", dueDate: "", checklist: [] }}
       />
     );
 
     // when - 오버레이 클릭
-    screen.getByTestId("todo-modal-overlay").click();
+    await userEvent.click(screen.getByTestId("todo-modal-overlay"));
 
     // then - onOpenChange가 false로 호출되었는지 확인
     expect(onOpenChangeMock).toHaveBeenCalledWith(false);
   });
 
-  it("calls onSave with correct data when save button is clicked", () => {
+  it("calls onSave with correct data when save button is clicked", async () => {
     // given
     const onOpenChangeMock = vi.fn();
     const onSaveMock = vi.fn();
-    const initialTodo = {
-      title: "Test Todo",
-      detail: "Test Detail",
-      dueDate: "2025-07-24",
-      status: "TODO" as const,
-      checklist: [{ id: 1, text: "Item 1", done: false }],
-    };
+    const initialTodo = { ...baseTodo, dueDate: "2025-07-24" };
 
     render(
       <TodoModal
@@ -142,11 +115,12 @@ describe("TodoModal", () => {
     );
 
     // when - detail 수정, checkbox 클릭, Save 버튼 클릭
-    const detailInput = screen.getByTestId("todo-detail-input");
-    fireEvent.change(detailInput, { target: { value: "Updated Detail Text" } });
-    screen.getByTestId("todo-checklist-checkbox-1").click();
+    const detailInput = screen.getByTestId("todo-detail-input") as HTMLInputElement;
+    await userEvent.clear(detailInput);
+    await userEvent.type(detailInput, "Updated Detail Text");
+    await userEvent.click(screen.getByTestId("todo-checklist-checkbox-1"));
 
-    screen.getByTestId("todo-save-button").click();
+    await userEvent.click(screen.getByTestId("todo-save-button"));
 
     // then - onSave가 올바른 데이터와 함께 호출되었는지 확인
     expect(onSaveMock).toHaveBeenCalledTimes(1);

--- a/src/pages/todo/Todos.test.tsx
+++ b/src/pages/todo/Todos.test.tsx
@@ -2,10 +2,10 @@ import { describe, it, expect, vi } from "vitest";
 import {
   render,
   screen,
-  fireEvent,
   within,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import Todos from "./Todos";
 import { server } from "../../mocks/server";
 
@@ -49,7 +49,7 @@ describe("Todos", () => {
     const listItem = await screen.findByTestId("todo-item-1");
 
     const deleteButton = within(listItem).getByTestId("delete-todo-1");
-    fireEvent.click(deleteButton);
+    await userEvent.click(deleteButton);
 
     // then
     // item dom 이 사라질 때까지 기다리기


### PR DESCRIPTION
## Summary
- use `@testing-library/user-event` in Todos tests
- click delete button with userEvent

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_688425a05804832a9dfafe3adfb9b031